### PR TITLE
Canonicalize and verify log file path before using — fixes #1

### DIFF
--- a/libexec/logcat
+++ b/libexec/logcat
@@ -20,19 +20,21 @@ if [ -z "$1" ]; then
   echo "Usage: $PROGNAME <file>"
   exit 1
 else
-  if [[ "$1" == "/var/log/"* ]]; then
-    if [ -f "$1" ]; then
-      diag_log "$PROGNAME: viewing file: $1"
-      cat "$1"
+  logfile="$1"
+  if [[ ! "$logfile" =~ ^/ ]]; then
+    logfile="/var/log/$logfile"
+  fi
+  logfile=$(realpath --canonicalize-missing --quiet "$logfile")
+  if [[ ! "$logfile" =~ ^/var/log ]]; then
+    diag_err "$PROGNAME: file is not in /var/log: $1"
+    exit 1
+  else 
+    if [ -f "$logfile" ]; then
+      diag_log "$PROGNAME: viewing file: $logfile"
+      cat "$logfile"
     else
-      diag_err "$PROGNAME: file not found: $1"
+      diag_err "$PROGNAME: file not found: $logfile"
       exit 1
     fi
-  elif [ -f "/var/log/$1" ]; then
-    diag_log "$PROGNAME: viewing file: /var/log/$1"
-    cat "/var/log/$1"
-  else
-    diag_err "$PROGNAME: file not found: /var/log/$1"
-    exit 1
   fi
 fi

--- a/libexec/logtail
+++ b/libexec/logtail
@@ -23,18 +23,21 @@ if [ -z "$1" ]; then
 else
   files=()
   for a in "$@"; do
-    if [[ "$a" == "/var/log/"* ]]; then
-      if [ -f "$a" ]; then
-        files+=("$a")
+    logfile="$a"
+    if [[ ! "$logfile" =~ ^/ ]]; then
+      logfile="/var/log/$logfile"
+    fi
+    logfile=$(realpath --canonicalize-missing --quiet "$logfile")
+    if [[ ! "$logfile" =~ ^/var/log ]]; then
+      diag_err "$PROGNAME: file is not in /var/log: $a"
+      exit 1
+    else 
+      if [ -f "$logfile" ]; then
+        files+=("$logfile")
       else
-        diag_err "$PROGNAME: file not found: $a"
+        diag_err "$PROGNAME: file not found: $logfile"
         exit 1
       fi
-    elif [ -f "/var/log/$a" ]; then
-      files+=("/var/log/$a")
-    else
-      diag_err "$PROGNAME: file not found: /var/log/$a"
-      exit 1
     fi
   done
   diag_log "$PROGNAME: using file list: ${files[@]}"

--- a/libexec/logview
+++ b/libexec/logview
@@ -22,19 +22,21 @@ if [ -z "$1" ]; then
   echo "Usage: $PROGNAME <file>"
   exit 1
 else
-  if [[ "$1" == "/var/log/"* ]]; then
-    if [ -f "$1" ]; then
-      diag_log "$PROGNAME: viewing file: $1"
-      less "$1"
+  logfile="$1"
+  if [[ ! "$logfile" =~ ^/ ]]; then
+    logfile="/var/log/$logfile"
+  fi
+  logfile=$(realpath --canonicalize-missing --quiet "$logfile")
+  if [[ ! "$logfile" =~ ^/var/log ]]; then
+    diag_err "$PROGNAME: file is not in /var/log: $1"
+    exit 1
+  else 
+    if [ -f "$logfile" ]; then
+      diag_log "$PROGNAME: viewing file: $logfile"
+      less "$logfile"
     else
-      diag_err "$PROGNAME: file not found: $1"
+      diag_err "$PROGNAME: file not found: $logfile"
       exit 1
     fi
-  elif [ -f "/var/log/$1" ]; then
-    diag_log "$PROGNAME: viewing file: /var/log/$1"
-    less "/var/log/$1"
-  else
-    diag_err "$PROGNAME: file not found: /var/log/$1"
-    exit 1
   fi
 fi


### PR DESCRIPTION
`logview`, `logcat`, and `logtail` are modified to enforce that the requested log file is under `/var/log` (preventing directory traversal attacks): as before, prepend `/var/log` to relative filepath supplied arguments, but then use `realpath` to canonicalize the (absolute) path; now check that this canonicalized absolute form begins with `/var/log`, if it doesn't, error out, otherwise proceed to check the file exists and view/cat/tail as appropriate.